### PR TITLE
Bump/dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
         <dependency>
             <groupId>jakarta.persistence</groupId>
             <artifactId>jakarta.persistence-api</artifactId>
-            <version>3.1.0</version>
+            <version>3.2.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -397,14 +397,6 @@
                 <configuration>
                     <repoToken>${coveralls.token}</repoToken>
                 </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>javax.xml.bind</groupId>
-                        <artifactId>jaxb-api</artifactId>
-                        <version>2.3.1</version>
-                    </dependency>
-                </dependencies>
-
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <version.org.mockito.mockito-core>5.21.0</version.org.mockito.mockito-core>
 
         <!-- build -->
-        <version.org.codehaus.mojo.build-helper-maven-plugin>3.4.0</version.org.codehaus.mojo.build-helper-maven-plugin>
+        <version.org.codehaus.mojo.build-helper-maven-plugin>3.6.1</version.org.codehaus.mojo.build-helper-maven-plugin>
         <version.org.jacoco.maven-plugin>0.8.12</version.org.jacoco.maven-plugin>
         <version.org.eluder.coveralls.maven-plugin>4.3.0</version.org.eluder.coveralls.maven-plugin>
         <coveralls.token>myToken</coveralls.token>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <!-- build -->
         <version.org.codehaus.mojo.build-helper-maven-plugin>3.6.1</version.org.codehaus.mojo.build-helper-maven-plugin>
         <version.org.jacoco.maven-plugin>0.8.14</version.org.jacoco.maven-plugin>
-        <version.org.eluder.coveralls.maven-plugin>4.3.0</version.org.eluder.coveralls.maven-plugin>
+        <coveralls.maven-plugin>5.0.0</coveralls.maven-plugin>
         <coveralls.token>myToken</coveralls.token>
         <jacoco.reportFolder>${project.build.directory}/jacoco/${artifactId}</jacoco.reportFolder>
         <jacoco.utReportFile>${jacoco.reportFolder}/test.exec</jacoco.utReportFile>
@@ -391,9 +391,9 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.eluder.coveralls</groupId>
+                <groupId>com.github.hazendaz.maven</groupId>
                 <artifactId>coveralls-maven-plugin</artifactId>
-                <version>${version.org.eluder.coveralls.maven-plugin}</version>
+                <version>${coveralls.maven-plugin}</version>
                 <configuration>
                     <repoToken>${coveralls.token}</repoToken>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <version.io.github.wistefan.dcql-java>0.0.1</version.io.github.wistefan.dcql-java>
 
         <!-- test -->
-        <version.org.mockito.mocktio-all>1.10.19</version.org.mockito.mocktio-all>
+        <version.org.mockito.mockito-core>5.21.0</version.org.mockito.mockito-core>
 
         <!-- build -->
         <version.org.codehaus.mojo.build-helper-maven-plugin>3.4.0</version.org.codehaus.mojo.build-helper-maven-plugin>
@@ -231,8 +231,8 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>${version.org.mockito.mocktio-all}</version>
+            <artifactId>mockito-core</artifactId>
+            <version>${version.org.mockito.mockito-core}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 
         <!-- lazy dev -->
         <version.org.mapstruct>1.6.3</version.org.mapstruct>
-        <version.org.projectlombok>1.18.36</version.org.projectlombok>
+        <version.org.projectlombok>1.18.42</version.org.projectlombok>
 
         <!-- logging -->
         <version.io.kokuwa.micronaut.logging>3.1.0</version.io.kokuwa.micronaut.logging>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.micronaut.platform</groupId>
         <artifactId>micronaut-parent</artifactId>
-        <version>4.8.2</version>
+        <version>4.10.6</version>
     </parent>
 
     <groupId>org.fiware.iam</groupId>
@@ -32,8 +32,7 @@
     <properties>
         <jdk.version>21</jdk.version>
         <release.version>21</release.version>
-        <micronaut.version>4.8.2</micronaut.version>
-        <micronaut.data.version>4.12.0</micronaut.data.version>
+        <micronaut.version>${project.parent.version}</micronaut.version>
 
         <!-- project info -->
         <project.author.name>Stefan Wiedemann</project.author.name>
@@ -85,17 +84,6 @@
         <jacoco.utReportFile>${jacoco.reportFolder}/test.exec</jacoco.utReportFile>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.micronaut.data</groupId>
-                <artifactId>micronaut-data-bom</artifactId>
-                <version>${micronaut.data.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
 
         <!-- lazy dev -->
@@ -459,7 +447,7 @@
                         <path>
                             <groupId>io.micronaut.validation</groupId>
                             <artifactId>micronaut-validation</artifactId>
-                            <version>4.8.0</version>
+                            <version>${micronaut.validation.version}</version>
                         </path>
                     </annotationProcessorPaths>
                     <compilerArgs>
@@ -510,7 +498,7 @@
                                 <path>
                                     <groupId>io.micronaut.validation</groupId>
                                     <artifactId>micronaut-validation</artifactId>
-                                    <version>4.8.0</version>
+                                    <version>${micronaut.validation.version}</version>
                                 </path>
                             </annotationProcessorPaths>
                             <compilerArgs>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <image.repository>fiware</image.repository>
 
         <!-- lazy dev -->
-        <version.org.mapstruct>1.5.3.Final</version.org.mapstruct>
+        <version.org.mapstruct>1.6.3</version.org.mapstruct>
         <version.org.projectlombok>1.18.36</version.org.projectlombok>
 
         <!-- logging -->
@@ -95,9 +95,7 @@
         <dependency>
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
-            <version>
-                ${version.org.mapstruct}
-            </version>
+            <version>${version.org.mapstruct}</version>
         </dependency>
 
         <!-- micronaut -->

--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,8 @@
         <version.io.kokuwa.micronaut.logging>3.1.0</version.io.kokuwa.micronaut.logging>
 
         <!-- code gen -->
-        <version.org.openapitools.generator-maven-plugin>6.6.0</version.org.openapitools.generator-maven-plugin>
-        <version.io.kokuwa.micronaut.codegen>3.4.6</version.io.kokuwa.micronaut.codegen>
+        <version.org.openapitools.generator-maven-plugin>7.17.0</version.org.openapitools.generator-maven-plugin>
+        <version.io.kokuwa.micronaut.codegen>4.5.0</version.io.kokuwa.micronaut.codegen>
 
         <!-- dcql -->
         <version.io.github.wistefan.dcql-java>0.0.1</version.io.github.wistefan.dcql-java>
@@ -282,6 +282,7 @@
                                 <supportAsync>false</supportAsync>
                                 <jacksonDatabindNullable>true</jacksonDatabindNullable>
                                 <generateExamples>true</generateExamples>
+                                <serdeable>false</serdeable>
                             </configOptions>
                             <typeMappings>
                                 <typeMapping>java.util.Date=java.time.Instant</typeMapping>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
 
         <!-- build -->
         <version.org.codehaus.mojo.build-helper-maven-plugin>3.6.1</version.org.codehaus.mojo.build-helper-maven-plugin>
-        <version.org.jacoco.maven-plugin>0.8.12</version.org.jacoco.maven-plugin>
+        <version.org.jacoco.maven-plugin>0.8.14</version.org.jacoco.maven-plugin>
         <version.org.eluder.coveralls.maven-plugin>4.3.0</version.org.eluder.coveralls.maven-plugin>
         <coveralls.token>myToken</coveralls.token>
         <jacoco.reportFolder>${project.build.directory}/jacoco/${artifactId}</jacoco.reportFolder>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <version.org.jacoco.maven-plugin>0.8.14</version.org.jacoco.maven-plugin>
         <coveralls.maven-plugin>5.0.0</coveralls.maven-plugin>
         <coveralls.token>myToken</coveralls.token>
-        <jacoco.reportFolder>${project.build.directory}/jacoco/${artifactId}</jacoco.reportFolder>
+        <jacoco.reportFolder>${project.build.directory}/jacoco/${project.artifactId}</jacoco.reportFolder>
         <jacoco.utReportFile>${jacoco.reportFolder}/test.exec</jacoco.utReportFile>
     </properties>
 
@@ -174,8 +174,8 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/fiware/iam/ServiceMapper.java
+++ b/src/main/java/org/fiware/iam/ServiceMapper.java
@@ -1,16 +1,48 @@
 package org.fiware.iam;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.github.wistefan.dcql.model.*;
-import org.fiware.iam.ccs.model.*;
-import org.fiware.iam.repository.*;
+import io.github.wistefan.dcql.model.ClaimsQuery;
+import io.github.wistefan.dcql.model.CredentialFormat;
+import io.github.wistefan.dcql.model.CredentialQuery;
+import io.github.wistefan.dcql.model.CredentialSetQuery;
+import io.github.wistefan.dcql.model.DcqlQuery;
+import io.github.wistefan.dcql.model.TrustedAuthorityQuery;
+import io.github.wistefan.dcql.model.TrustedAuthorityType;
+import org.fiware.iam.ccs.model.ClaimsQueryVO;
+import org.fiware.iam.ccs.model.CredentialQueryVO;
+import org.fiware.iam.ccs.model.CredentialSetQueryVO;
+import org.fiware.iam.ccs.model.CredentialVO;
+import org.fiware.iam.ccs.model.DCQLVO;
+import org.fiware.iam.ccs.model.HolderVerificationVO;
+import org.fiware.iam.ccs.model.InputDescriptorVO;
+import org.fiware.iam.ccs.model.JwtInclusionVO;
+import org.fiware.iam.ccs.model.MetaDataQueryVO;
+import org.fiware.iam.ccs.model.PresentationDefinitionVO;
+import org.fiware.iam.ccs.model.ServiceScopesEntryVO;
+import org.fiware.iam.ccs.model.ServiceVO;
+import org.fiware.iam.ccs.model.TrustedAuthorityQueryVO;
+import org.fiware.iam.ccs.model.TrustedParticipantsListEndpointVO;
+import org.fiware.iam.repository.AuthorizationType;
 import org.fiware.iam.repository.Credential;
+import org.fiware.iam.repository.EndpointEntry;
+import org.fiware.iam.repository.EndpointType;
+import org.fiware.iam.repository.Format;
+import org.fiware.iam.repository.FormatObject;
+import org.fiware.iam.repository.InputDescriptor;
+import org.fiware.iam.repository.JwtInclusion;
+import org.fiware.iam.repository.ListType;
+import org.fiware.iam.repository.PresentationDefinition;
+import org.fiware.iam.repository.ScopeEntry;
+import org.fiware.iam.repository.Service;
 import org.mapstruct.Mapper;
 
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static org.fiware.iam.ccs.model.MetaDataQueryVO.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * Responsible for mapping entities from the Service api domain to the internal model.
@@ -18,374 +50,375 @@ import static org.fiware.iam.ccs.model.MetaDataQueryVO.*;
 @Mapper(componentModel = "jsr330")
 public interface ServiceMapper {
 
-	static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    String JSON_PROPERTY_VCT_VALUES = "vct_values";
+    String JSON_PROPERTY_DOCTYPE_VALUE = "doctype_value";
+    String JSON_PROPERTY_TYPE_VALUES = "type_values";
 
-	default Service map(ServiceVO serviceVO) {
-		if (serviceVO == null) {
-			return null;
-		}
-		Service service = new Service();
-		service.setId(serviceVO.getId());
-		service.setAuthorizationType(map(serviceVO.getAuthorizationType()));
-		service.setDefaultOidcScope(serviceVO.getDefaultOidcScope());
-		service.setOidcScopes(
-				serviceVO.getOidcScopes()
-						.entrySet()
-						.stream()
-						.map(e -> {
-							ScopeEntry scopeEntry = new ScopeEntry();
-							scopeEntry.setScopeKey(e.getKey());
-							scopeEntry.setService(service);
-							scopeEntry.setCredentials(Optional.ofNullable(e.getValue().getCredentials()).
-									orElse(List.of()).stream().map(this::map).toList());
-							scopeEntry.setPresentationDefinition(this.map(e.getValue().getPresentationDefinition()));
-							scopeEntry.setDcqlQuery(this.map(e.getValue().getDcql()));
-							return scopeEntry;
-						})
-						.toList());
-		return service;
-	}
+    default Service map(ServiceVO serviceVO) {
+        if (serviceVO == null) {
+            return null;
+        }
+        Service service = new Service();
+        service.setId(serviceVO.getId());
+        service.setAuthorizationType(map(serviceVO.getAuthorizationType()));
+        service.setDefaultOidcScope(serviceVO.getDefaultOidcScope());
+        service.setOidcScopes(
+                serviceVO.getOidcScopes()
+                        .entrySet()
+                        .stream()
+                        .map(e -> {
+                            ScopeEntry scopeEntry = new ScopeEntry();
+                            scopeEntry.setScopeKey(e.getKey());
+                            scopeEntry.setCredentials(Optional.ofNullable(e.getValue().getCredentials()).
+                                    orElse(List.of()).stream().map(this::map).toList());
+                            scopeEntry.setPresentationDefinition(this.map(e.getValue().getPresentationDefinition()));
+                            scopeEntry.setDcqlQuery(this.map(e.getValue().getDcql()));
+                            return scopeEntry;
+                        })
+                        .toList());
+        return service;
+    }
 
-	default ServiceVO map(Service service) {
-		if (service == null) {
-			return null;
-		}
-		return new ServiceVO().id(service.getId())
-				.authorizationType(map(service.getAuthorizationType()))
-				.defaultOidcScope(service.getDefaultOidcScope())
-				.oidcScopes(this.toOidcScopes(service.getOidcScopes()));
-	}
+    default ServiceVO map(Service service) {
+        if (service == null) {
+            return null;
+        }
+        return new ServiceVO().id(service.getId())
+                .authorizationType(map(service.getAuthorizationType()))
+                .defaultOidcScope(service.getDefaultOidcScope())
+                .oidcScopes(this.toOidcScopes(service.getOidcScopes()));
+    }
 
-	default PresentationDefinition map(PresentationDefinitionVO presentationDefinitionVO) {
-		if (presentationDefinitionVO == null) {
-			return null;
-		}
+    default PresentationDefinition map(PresentationDefinitionVO presentationDefinitionVO) {
+        if (presentationDefinitionVO == null) {
+            return null;
+        }
 
-		PresentationDefinition presentationDefinition = new PresentationDefinition();
-		presentationDefinition.setId(presentationDefinitionVO.getId());
-		presentationDefinition.setName(presentationDefinitionVO.getName());
-		presentationDefinition.setPurpose(presentationDefinitionVO.getPurpose());
-		presentationDefinition.setInputDescriptors(this.mapInputDescriptors(presentationDefinitionVO
-				.getInputDescriptors()));
-		presentationDefinition.setFormat(this.mapFormatVO(presentationDefinitionVO
-				.getFormat()));
+        PresentationDefinition presentationDefinition = new PresentationDefinition();
+        presentationDefinition.setId(presentationDefinitionVO.getId());
+        presentationDefinition.setName(presentationDefinitionVO.getName());
+        presentationDefinition.setPurpose(presentationDefinitionVO.getPurpose());
+        presentationDefinition.setInputDescriptors(this.mapInputDescriptors(presentationDefinitionVO
+                .getInputDescriptors()));
+        presentationDefinition.setFormat(this.mapFormatVO(presentationDefinitionVO
+                .getFormat()));
 
-		return presentationDefinition;
-	}
+        return presentationDefinition;
+    }
 
-	default Collection<InputDescriptor> mapInputDescriptors(Collection<InputDescriptorVO> inputDescriptorVOS) {
-		if (inputDescriptorVOS == null) {
-			return null;
-		}
-		return inputDescriptorVOS
-				.stream()
-				.map(this::mapInputDescriptorVO).toList();
-	}
+    default Collection<InputDescriptor> mapInputDescriptors(Collection<InputDescriptorVO> inputDescriptorVOS) {
+        if (inputDescriptorVOS == null) {
+            return null;
+        }
+        return inputDescriptorVOS
+                .stream()
+                .map(this::mapInputDescriptorVO).toList();
+    }
 
-	default Collection<Format> mapFormatVO(Map<String, Object> formatsMap) {
-		if (formatsMap == null) {
-			return null;
-		}
+    default Collection<Format> mapFormatVO(Map<String, Object> formatsMap) {
+        if (formatsMap == null) {
+            return null;
+        }
 
-		return formatsMap
-				.entrySet()
-				.stream()
-				.map(e -> {
-					FormatObject formatObject = OBJECT_MAPPER.convertValue(e.getValue(), FormatObject.class);
-					Format format = new Format();
-					format.setFormatKey(e.getKey());
-					format.setAlg(formatObject.getAlg());
-					format.setProofType(formatObject.getProofType());
-					return format;
-				}).toList();
-	}
+        return formatsMap
+                .entrySet()
+                .stream()
+                .map(e -> {
+                    FormatObject formatObject = OBJECT_MAPPER.convertValue(e.getValue(), FormatObject.class);
+                    Format format = new Format();
+                    format.setFormatKey(e.getKey());
+                    format.setAlg(formatObject.getAlg());
+                    format.setProofType(formatObject.getProofType());
+                    return format;
+                }).toList();
+    }
 
-	default Map<String, Object> mapFormats(Collection<Format> formats) {
-		if (formats == null) {
-			return null;
-		}
+    default Map<String, Object> mapFormats(Collection<Format> formats) {
+        if (formats == null) {
+            return null;
+        }
 
-		Map<String, Object> formatsMap = new HashMap<>();
+        Map<String, Object> formatsMap = new HashMap<>();
 
-		formats.stream()
-				.forEach(format -> {
-					Map<String, Object> formatMap = new HashMap<>();
-					Optional.ofNullable(format.getAlg()).ifPresent(algs -> formatMap.put("alg", algs));
-					Optional.ofNullable(format.getProofType()).ifPresent(pt -> formatMap.put("proof_type", pt));
-					formatsMap.put(format.getFormatKey(), formatMap);
-				});
+        formats.forEach(format -> {
+            Map<String, Object> formatMap = new HashMap<>();
+            Optional.ofNullable(format.getAlg()).ifPresent(algs -> formatMap.put("alg", algs));
+            Optional.ofNullable(format.getProofType()).ifPresent(pt -> formatMap.put("proof_type", pt));
+            formatsMap.put(format.getFormatKey(), formatMap);
+        });
 
-		return formatsMap;
-	}
+        return formatsMap;
+    }
 
-	AuthorizationType map(ServiceVO.AuthorizationType authorizationType);
+    AuthorizationType map(ServiceVO.AuthorizationType authorizationType);
 
-	ServiceVO.AuthorizationType map(AuthorizationType authorizationType);
+    ServiceVO.AuthorizationType map(AuthorizationType authorizationType);
 
-	InputDescriptorVO mapInputDescriptor(InputDescriptor inputDescriptor);
+    InputDescriptorVO mapInputDescriptor(InputDescriptor inputDescriptor);
 
-	InputDescriptor mapInputDescriptorVO(InputDescriptorVO inputDescriptor);
+    InputDescriptor mapInputDescriptorVO(InputDescriptorVO inputDescriptor);
 
-	PresentationDefinitionVO map(PresentationDefinition presentationDefinition);
+    PresentationDefinitionVO map(PresentationDefinition presentationDefinition);
 
-	TrustedParticipantsListEndpointVO.Type map(ListType type);
+    TrustedParticipantsListEndpointVO.Type map(ListType type);
 
-	ListType map(TrustedParticipantsListEndpointVO.Type type);
+    ListType map(TrustedParticipantsListEndpointVO.Type type);
 
-	default Map<String, ServiceScopesEntryVO> toOidcScopes(Collection<ScopeEntry> scopeEntries) {
-		if (scopeEntries == null) {
-			return null;
-		}
-		Map<String, ServiceScopesEntryVO> scopes = new LinkedHashMap<>();
-		scopeEntries
-				.forEach(entry -> {
-					ServiceScopesEntryVO scopesEntryVO = new ServiceScopesEntryVO();
-					scopesEntryVO.setPresentationDefinition(this.map(entry.getPresentationDefinition()));
-					scopesEntryVO.setCredentials(this.map(entry.getCredentials()));
-					scopesEntryVO.setDcql(this.map(entry.getDcqlQuery()));
-					scopes.put(entry.getScopeKey(), scopesEntryVO);
-				});
-		return scopes;
-	}
+    default Map<String, ServiceScopesEntryVO> toOidcScopes(Collection<ScopeEntry> scopeEntries) {
+        if (scopeEntries == null) {
+            return null;
+        }
+        Map<String, ServiceScopesEntryVO> scopes = new LinkedHashMap<>();
+        scopeEntries
+                .forEach(entry -> {
+                    ServiceScopesEntryVO scopesEntryVO = new ServiceScopesEntryVO();
+                    scopesEntryVO.setPresentationDefinition(this.map(entry.getPresentationDefinition()));
+                    scopesEntryVO.setCredentials(this.map(entry.getCredentials()));
+                    scopesEntryVO.setDcql(this.map(entry.getDcqlQuery()));
+                    scopes.put(entry.getScopeKey(), scopesEntryVO);
+                });
+        return scopes;
+    }
 
-	DCQLVO map(DcqlQuery dcqlQuery);
+    DCQLVO map(DcqlQuery dcqlQuery);
 
-	DcqlQuery map(DCQLVO dcqlvo);
+    DcqlQuery map(DCQLVO dcqlvo);
 
-	default CredentialQuery map(CredentialQueryVO credentialQueryVO) {
-		if (credentialQueryVO == null) {
-			return null;
-		}
-		CredentialQuery credentialQuery = new CredentialQuery();
-		credentialQuery.setId(credentialQueryVO.getId());
-		credentialQuery.setFormat(this.map(credentialQueryVO.getFormat()));
-		credentialQuery.setMultiple(credentialQueryVO.getMultiple());
-		credentialQuery.setClaims(Optional.ofNullable(credentialQueryVO.getClaims()).orElse(List.of())
-				.stream().map(this::map).toList());
-		credentialQuery.setMeta(this.map(credentialQueryVO.getMeta()));
-		credentialQuery.setRequireCryptographicHolderBinding(credentialQueryVO.getRequireCryptographicHolderBinding());
-		credentialQuery.setClaimSets(credentialQueryVO.getClaimSets());
-		credentialQuery.setTrustedAuthorities(Optional.ofNullable(credentialQueryVO.getTrustedAuthorities()).orElse(List.of())
-				.stream().map(this::map).toList());
-		return credentialQuery;
-	}
+    default CredentialQuery map(CredentialQueryVO credentialQueryVO) {
+        if (credentialQueryVO == null) {
+            return null;
+        }
+        CredentialQuery credentialQuery = new CredentialQuery();
+        credentialQuery.setId(credentialQueryVO.getId());
+        credentialQuery.setFormat(this.map(credentialQueryVO.getFormat()));
+        credentialQuery.setMultiple(credentialQueryVO.getMultiple());
+        credentialQuery.setClaims(Optional.ofNullable(credentialQueryVO.getClaims()).orElse(List.of())
+                .stream().map(this::map).toList());
+        credentialQuery.setMeta(this.map(credentialQueryVO.getMeta()));
+        credentialQuery.setRequireCryptographicHolderBinding(credentialQueryVO.getRequireCryptographicHolderBinding());
+        credentialQuery.setClaimSets(credentialQueryVO.getClaimSets());
+        credentialQuery.setTrustedAuthorities(Optional.ofNullable(credentialQueryVO.getTrustedAuthorities()).orElse(List.of())
+                .stream().map(this::map).toList());
+        return credentialQuery;
+    }
 
-	default CredentialQueryVO map(CredentialQuery credentialQuery) {
-		if (credentialQuery == null) {
-			return null;
-		}
-		CredentialQueryVO credentialQueryVO = new CredentialQueryVO();
-		credentialQueryVO.setId(credentialQuery.getId());
-		credentialQueryVO.setFormat(this.map(credentialQuery.getFormat()));
-		credentialQueryVO.setMultiple(credentialQuery.getMultiple());
-		credentialQueryVO.setClaims(Optional.ofNullable(credentialQuery.getClaims()).orElse(List.of())
-				.stream().map(this::map).toList());
-		credentialQueryVO.setMeta(map(credentialQuery.getMeta()));
-		credentialQueryVO.setRequireCryptographicHolderBinding(credentialQuery.getRequireCryptographicHolderBinding());
-		credentialQueryVO.setClaimSets(credentialQuery.getClaimSets());
-		credentialQueryVO.setTrustedAuthorities(Optional.ofNullable(credentialQuery.getTrustedAuthorities()).orElse(List.of())
-				.stream().map(this::map).toList());
-		return credentialQueryVO;
-	}
+    default CredentialQueryVO map(CredentialQuery credentialQuery) {
+        if (credentialQuery == null) {
+            return null;
+        }
+        CredentialQueryVO credentialQueryVO = new CredentialQueryVO();
+        credentialQueryVO.setId(credentialQuery.getId());
+        credentialQueryVO.setFormat(this.map(credentialQuery.getFormat()));
+        credentialQueryVO.setMultiple(credentialQuery.getMultiple());
+        credentialQueryVO.setClaims(Optional.ofNullable(credentialQuery.getClaims()).orElse(List.of())
+                .stream().map(this::map).toList());
+        credentialQueryVO.setMeta(map(credentialQuery.getMeta()));
+        credentialQueryVO.setRequireCryptographicHolderBinding(credentialQuery.getRequireCryptographicHolderBinding());
+        credentialQueryVO.setClaimSets(credentialQuery.getClaimSets());
+        credentialQueryVO.setTrustedAuthorities(Optional.ofNullable(credentialQuery.getTrustedAuthorities()).orElse(List.of())
+                .stream().map(this::map).toList());
+        return credentialQueryVO;
+    }
 
-	TrustedAuthorityQueryVO map(TrustedAuthorityQuery trustedAuthorityQuery);
+    TrustedAuthorityQueryVO map(TrustedAuthorityQuery trustedAuthorityQuery);
 
-	TrustedAuthorityQuery map(TrustedAuthorityQueryVO trustedAuthorityQueryVO);
+    TrustedAuthorityQuery map(TrustedAuthorityQueryVO trustedAuthorityQueryVO);
 
-	default TrustedAuthorityType map(String type) {
-		return TrustedAuthorityType.fromValue(type);
-	}
+    default TrustedAuthorityType map(String type) {
+        return TrustedAuthorityType.fromValue(type);
+    }
 
-	default String map(TrustedAuthorityType type) {
-		return type.getValue();
-	}
+    default String map(TrustedAuthorityType type) {
+        return type.getValue();
+    }
 
-	default Map<String, Object> map(MetaDataQueryVO metaDataQueryVO) {
-		if (metaDataQueryVO == null) {
-			return null;
-		}
-		Map<String, Object> metaMap = new HashMap<>();
-		if (metaDataQueryVO.getVctValues() != null) {
-			metaMap.put(JSON_PROPERTY_VCT_VALUES, metaDataQueryVO.getVctValues());
-		}
-		if (metaDataQueryVO.getTypeValues() != null) {
-			metaMap.put(JSON_PROPERTY_TYPE_VALUES, metaDataQueryVO.getTypeValues());
-		}
-		if (metaDataQueryVO.getDoctypeValue() != null) {
-			metaMap.put(JSON_PROPERTY_DOCTYPE_VALUE, metaDataQueryVO.getDoctypeValue());
-		}
-		return metaMap;
-	}
+    default Map<String, Object> map(MetaDataQueryVO metaDataQueryVO) {
+        if (metaDataQueryVO == null) {
+            return null;
+        }
+        Map<String, Object> metaMap = new HashMap<>();
+        if (metaDataQueryVO.getVctValues() != null) {
+            metaMap.put(JSON_PROPERTY_VCT_VALUES, metaDataQueryVO.getVctValues());
+        }
+        if (metaDataQueryVO.getTypeValues() != null) {
+            metaMap.put(JSON_PROPERTY_TYPE_VALUES, metaDataQueryVO.getTypeValues());
+        }
+        if (metaDataQueryVO.getDoctypeValue() != null) {
+            metaMap.put(JSON_PROPERTY_DOCTYPE_VALUE, metaDataQueryVO.getDoctypeValue());
+        }
+        return metaMap;
+    }
 
-	default MetaDataQueryVO map(Map<String, Object> meta) {
-		if (meta == null) {
-			return null;
-		}
-		MetaDataQueryVO metaDataQueryVO = new MetaDataQueryVO();
-		if (meta.containsKey(JSON_PROPERTY_VCT_VALUES)) {
-			metaDataQueryVO.setVctValues((List<String>) meta.get(JSON_PROPERTY_VCT_VALUES));
-		}
-		if (meta.containsKey(JSON_PROPERTY_DOCTYPE_VALUE)) {
-			metaDataQueryVO.setDoctypeValue((String) meta.get(JSON_PROPERTY_DOCTYPE_VALUE));
-		}
-		if (meta.containsKey(JSON_PROPERTY_TYPE_VALUES)) {
-			metaDataQueryVO.setTypeValues((List<List<String>>) meta.get(JSON_PROPERTY_TYPE_VALUES));
-		}
-		return metaDataQueryVO;
-	}
+    default MetaDataQueryVO map(Map<String, Object> meta) {
+        if (meta == null) {
+            return null;
+        }
+        MetaDataQueryVO metaDataQueryVO = new MetaDataQueryVO();
+        if (meta.containsKey(JSON_PROPERTY_VCT_VALUES)) {
+            metaDataQueryVO.setVctValues((List<String>) meta.get(JSON_PROPERTY_VCT_VALUES));
+        }
+        if (meta.containsKey(JSON_PROPERTY_DOCTYPE_VALUE)) {
+            metaDataQueryVO.setDoctypeValue((String) meta.get(JSON_PROPERTY_DOCTYPE_VALUE));
+        }
+        if (meta.containsKey(JSON_PROPERTY_TYPE_VALUES)) {
+            metaDataQueryVO.setTypeValues((List<List<String>>) meta.get(JSON_PROPERTY_TYPE_VALUES));
+        }
+        return metaDataQueryVO;
+    }
 
-	ClaimsQuery map(ClaimsQueryVO claimsQueryVO);
+    ClaimsQuery map(ClaimsQueryVO claimsQueryVO);
 
-	ClaimsQueryVO map(ClaimsQuery claimsQuery);
+    ClaimsQueryVO map(ClaimsQuery claimsQuery);
 
-	CredentialQueryVO.Format map(CredentialFormat credentialFormat);
+    CredentialQueryVO.Format map(CredentialFormat credentialFormat);
 
-	CredentialFormat map(CredentialQueryVO.Format credentialFormat);
+    CredentialFormat map(CredentialQueryVO.Format credentialFormat);
 
-	CredentialSetQueryVO map(CredentialSetQuery credentialSetQuery);
+    CredentialSetQueryVO map(CredentialSetQuery credentialSetQuery);
 
-	CredentialSetQuery map(CredentialSetQueryVO credentialSetQueryVO);
+    CredentialSetQuery map(CredentialSetQueryVO credentialSetQueryVO);
 
-	default EndpointEntry stringToEndpointEntry(String url) {
-		EndpointEntry entry = new EndpointEntry();
-		entry.setType(EndpointType.TRUSTED_PARTICIPANTS);
-		entry.setListType(ListType.EBSI);
-		entry.setEndpoint(url);
-		return entry;
-	}
+    default EndpointEntry stringToEndpointEntry(String url) {
+        EndpointEntry entry = new EndpointEntry();
+        entry.setType(EndpointType.TRUSTED_PARTICIPANTS);
+        entry.setListType(ListType.EBSI);
+        entry.setEndpoint(url);
+        return entry;
+    }
 
-	default Credential map(CredentialVO credentialVO) {
-		if (credentialVO == null) {
-			return null;
-		}
-		Credential credential = new Credential();
-		credential.setCredentialType(credentialVO.getType());
-		List<EndpointEntry> trustedList = new ArrayList<>();
-		Optional.ofNullable(issuersToEntries(credentialVO.getTrustedIssuersLists())).ifPresent(trustedList::addAll);
+    default Credential map(CredentialVO credentialVO) {
+        if (credentialVO == null) {
+            return null;
+        }
+        Credential credential = new Credential();
+        credential.setCredentialType(credentialVO.getType());
+        List<EndpointEntry> trustedList = new ArrayList<>();
+        Optional.ofNullable(issuersToEntries(credentialVO.getTrustedIssuersLists())).ifPresent(trustedList::addAll);
 
-		credentialVO.getTrustedParticipantsLists()
-				.forEach(tpl -> {
-					if (tpl instanceof String tplS) {
-						trustedList.add(stringToEndpointEntry(tplS));
-					} else {
-						trustedList.add(participantToEntry(OBJECT_MAPPER.convertValue(tpl, TrustedParticipantsListEndpointVO.class)));
-					}
-				});
+        credentialVO.getTrustedParticipantsLists()
+                .forEach(tpl -> {
+                    if (tpl instanceof String tplS) {
+                        trustedList.add(stringToEndpointEntry(tplS));
+                    } else {
+                        trustedList.add(participantToEntry(OBJECT_MAPPER.convertValue(tpl, TrustedParticipantsListEndpointVO.class)));
+                    }
+                });
 
-		credential.setTrustedLists(trustedList);
+        credential.setTrustedLists(trustedList);
 
-		if (credentialVO.getHolderVerification() != null) {
-			credential.setHolderClaim(credentialVO.getHolderVerification().getClaim());
-			credential.setVerifyHolder(credentialVO.getHolderVerification().getEnabled());
-		} else {
-			credential.setVerifyHolder(false);
-			credential.setHolderClaim(null);
-		}
-		credential.setRequireCompliance(credentialVO.getRequireCompliance());
-		credential.setJwtInclusion(map(credentialVO.getJwtInclusion()));
-		return credential;
-	}
+        if (credentialVO.getHolderVerification() != null) {
+            credential.setHolderClaim(credentialVO.getHolderVerification().getClaim());
+            credential.setVerifyHolder(credentialVO.getHolderVerification().getEnabled());
+        } else {
+            credential.setVerifyHolder(false);
+            credential.setHolderClaim(null);
+        }
+        credential.setRequireCompliance(credentialVO.getRequireCompliance());
+        credential.setJwtInclusion(map(credentialVO.getJwtInclusion()));
+        return credential;
+    }
 
-	JwtInclusion map(JwtInclusionVO jwtInclusionVO);
+    JwtInclusion map(JwtInclusionVO jwtInclusionVO);
 
-	JwtInclusionVO map(JwtInclusion jwtInclusion);
+    JwtInclusionVO map(JwtInclusion jwtInclusion);
 
-	default List<CredentialVO> map(Collection<Credential> credentials) {
-		if (credentials == null) {
-			return null;
-		}
-		return credentials.stream().map(this::map).toList();
-	}
+    default List<CredentialVO> map(Collection<Credential> credentials) {
+        if (credentials == null) {
+            return null;
+        }
+        return credentials.stream().map(this::map).toList();
+    }
 
-	default CredentialVO map(Credential credential) {
-		if (credential == null) {
-			return null;
-		}
-		return new CredentialVO()
-				.type(credential.getCredentialType())
-				.trustedIssuersLists(entriesToIssuers(credential.getTrustedLists()))
-				.trustedParticipantsLists(entriesToParticipants(credential.getTrustedLists()).stream().map(Object.class::cast).toList())
-				.requireCompliance(credential.isRequireCompliance())
-				.jwtInclusion(map(credential.getJwtInclusion()))
-				.holderVerification(new HolderVerificationVO()
-						.enabled(credential.isVerifyHolder())
-						.claim(credential.getHolderClaim()));
-	}
+    default CredentialVO map(Credential credential) {
+        if (credential == null) {
+            return null;
+        }
+        return new CredentialVO()
+                .type(credential.getCredentialType())
+                .trustedIssuersLists(entriesToIssuers(credential.getTrustedLists()))
+                .trustedParticipantsLists(entriesToParticipants(credential.getTrustedLists()).stream().map(Object.class::cast).toList())
+                .requireCompliance(credential.isRequireCompliance())
+                .jwtInclusion(map(credential.getJwtInclusion()))
+                .holderVerification(new HolderVerificationVO()
+                        .enabled(credential.isVerifyHolder())
+                        .claim(credential.getHolderClaim()));
+    }
 
-	/**
-	 * Map a list of TrustedParticipantsListVO-entries, to a list of {@link EndpointEntry} with
-	 * type {{@link EndpointType#TRUSTED_PARTICIPANTS}
-	 */
-	default List<EndpointEntry> participantsToEntries(List<TrustedParticipantsListEndpointVO> endpoints) {
-		if (endpoints == null) {
-			return null;
-		}
-		return endpoints.stream()
-				.map(endpoint -> {
-					EndpointEntry entry = new EndpointEntry();
-					entry.setEndpoint(endpoint.getUrl());
-					entry.setListType(map(endpoint.getType()));
-					entry.setType(EndpointType.TRUSTED_PARTICIPANTS);
-					return entry;
-				})
-				.toList();
-	}
+    /**
+     * Map a list of TrustedParticipantsListVO-entries, to a list of {@link EndpointEntry} with
+     * type {{@link EndpointType#TRUSTED_PARTICIPANTS}
+     */
+    default List<EndpointEntry> participantsToEntries(List<TrustedParticipantsListEndpointVO> endpoints) {
+        if (endpoints == null) {
+            return null;
+        }
+        return endpoints.stream()
+                .map(endpoint -> {
+                    EndpointEntry entry = new EndpointEntry();
+                    entry.setEndpoint(endpoint.getUrl());
+                    entry.setListType(map(endpoint.getType()));
+                    entry.setType(EndpointType.TRUSTED_PARTICIPANTS);
+                    return entry;
+                })
+                .toList();
+    }
 
-	default EndpointEntry participantToEntry(TrustedParticipantsListEndpointVO trustedParticipantsListVO) {
-		if (trustedParticipantsListVO == null) {
-			return null;
-		}
-		EndpointEntry entry = new EndpointEntry();
-		entry.setEndpoint(trustedParticipantsListVO.getUrl());
-		entry.setListType(map(trustedParticipantsListVO.getType()));
-		entry.setType(EndpointType.TRUSTED_PARTICIPANTS);
-		return entry;
-	}
+    default EndpointEntry participantToEntry(TrustedParticipantsListEndpointVO trustedParticipantsListVO) {
+        if (trustedParticipantsListVO == null) {
+            return null;
+        }
+        EndpointEntry entry = new EndpointEntry();
+        entry.setEndpoint(trustedParticipantsListVO.getUrl());
+        entry.setListType(map(trustedParticipantsListVO.getType()));
+        entry.setType(EndpointType.TRUSTED_PARTICIPANTS);
+        return entry;
+    }
 
-	/**
-	 * Map a list of string-entries, encoding TrustedIssuers endpoints to a list of {@link EndpointEntry} with
-	 * type {{@link EndpointType#TRUSTED_ISSUERS}
-	 */
-	default List<EndpointEntry> issuersToEntries(List<String> endpoints) {
-		if (endpoints == null) {
-			return null;
-		}
-		return endpoints.stream()
-				.map(endpoint -> {
-					EndpointEntry entry = new EndpointEntry();
-					entry.setEndpoint(endpoint);
-					entry.setType(EndpointType.TRUSTED_ISSUERS);
-					return entry;
-				})
-				.toList();
-	}
+    /**
+     * Map a list of string-entries, encoding TrustedIssuers endpoints to a list of {@link EndpointEntry} with
+     * type {{@link EndpointType#TRUSTED_ISSUERS}
+     */
+    default List<EndpointEntry> issuersToEntries(List<String> endpoints) {
+        if (endpoints == null) {
+            return null;
+        }
+        return endpoints.stream()
+                .map(endpoint -> {
+                    EndpointEntry entry = new EndpointEntry();
+                    entry.setEndpoint(endpoint);
+                    entry.setType(EndpointType.TRUSTED_ISSUERS);
+                    return entry;
+                })
+                .toList();
+    }
 
-	/**
-	 * Return issuer endpoints from the {@link EndpointEntry} list to a list of strings
-	 */
-	default List<String> entriesToIssuers(List<EndpointEntry> endpoints) {
-		if (endpoints == null) {
-			return List.of();
-		}
-		return endpoints.stream()
-				.filter(entry -> entry.getType().equals(EndpointType.TRUSTED_ISSUERS))
-				.map(EndpointEntry::getEndpoint)
-				.toList();
-	}
+    /**
+     * Return issuer endpoints from the {@link EndpointEntry} list to a list of strings
+     */
+    default List<String> entriesToIssuers(List<EndpointEntry> endpoints) {
+        if (endpoints == null) {
+            return List.of();
+        }
+        return endpoints.stream()
+                .filter(entry -> entry.getType().equals(EndpointType.TRUSTED_ISSUERS))
+                .map(EndpointEntry::getEndpoint)
+                .toList();
+    }
 
-	/**
-	 * Return participant endpoints from the {@link EndpointEntry} list to a list of strings
-	 */
-	default List<TrustedParticipantsListEndpointVO> entriesToParticipants(List<EndpointEntry> endpoints) {
-		if (endpoints == null) {
-			return List.of();
-		}
-		return endpoints.stream()
-				.filter(entry -> entry.getType().equals(EndpointType.TRUSTED_PARTICIPANTS))
-				.map(entry -> new TrustedParticipantsListEndpointVO()
-						.type(map(entry.getListType()))
-						.url(entry.getEndpoint()))
-				.toList();
-	}
+    /**
+     * Return participant endpoints from the {@link EndpointEntry} list to a list of strings
+     */
+    default List<TrustedParticipantsListEndpointVO> entriesToParticipants(List<EndpointEntry> endpoints) {
+        if (endpoints == null) {
+            return List.of();
+        }
+        return endpoints.stream()
+                .filter(entry -> entry.getType().equals(EndpointType.TRUSTED_PARTICIPANTS))
+                .map(entry -> new TrustedParticipantsListEndpointVO()
+                        .type(map(entry.getListType()))
+                        .url(entry.getEndpoint()))
+                .toList();
+    }
 
 }

--- a/src/main/java/org/fiware/iam/rest/ServiceApiController.java
+++ b/src/main/java/org/fiware/iam/rest/ServiceApiController.java
@@ -12,9 +12,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.fiware.iam.ServiceMapper;
 import org.fiware.iam.ccs.api.ServiceApi;
-import org.fiware.iam.ccs.model.*;
+import org.fiware.iam.ccs.model.CredentialVO;
+import org.fiware.iam.ccs.model.ServiceScopesEntryVO;
+import org.fiware.iam.ccs.model.ServiceVO;
+import org.fiware.iam.ccs.model.ServicesVO;
 import org.fiware.iam.exception.ConflictException;
-import org.fiware.iam.repository.ScopeEntry;
 import org.fiware.iam.repository.ScopeEntryRepository;
 import org.fiware.iam.repository.Service;
 import org.fiware.iam.repository.ServiceRepository;
@@ -22,9 +24,7 @@ import org.fiware.iam.repository.ServiceRepository;
 import java.net.URI;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Implementation of the service api to configure services and there credentials
@@ -34,27 +34,27 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class ServiceApiController implements ServiceApi {
 
-	private final ServiceRepository serviceRepository;
+    private static final String PATH_GET_SERVICE = "/service/{id}";
+    private final ServiceRepository serviceRepository;
     private final ScopeEntryRepository scopeEntryRepository;
-	private final ServiceMapper serviceMapper;
+    private final ServiceMapper serviceMapper;
 
-	@Override
-	public HttpResponse<Object> createService(@NonNull ServiceVO serviceVO) {
-		if (serviceVO.getId() != null && serviceRepository.existsById(serviceVO.getId())) {
-			throw new ConflictException(String.format("The service with id %s already exists.", serviceVO.getId()),
-					serviceVO.getId());
-		}
-		validateServiceVO(serviceVO);
 
-		Service mappedService = serviceMapper.map(serviceVO);
+    @Override
+    public HttpResponse<Object> createService(@NonNull ServiceVO serviceVO) {
+        if (serviceVO.getId() != null && serviceRepository.existsById(serviceVO.getId())) {
+            throw new ConflictException(String.format("The service with id %s already exists.", serviceVO.getId()),
+                    serviceVO.getId());
+        }
+        validateServiceVO(serviceVO);
 
-		Service savedService = serviceRepository.save(mappedService);
+        Service mappedService = serviceMapper.map(serviceVO);
 
-		return HttpResponse.created(
-				URI.create(
-						ServiceApi.PATH_GET_SERVICE.replace(
-								"{id}", savedService.getId())));
-	}
+        Service savedService = serviceRepository.save(mappedService);
+
+        return HttpResponse.created(
+                URI.create(PATH_GET_SERVICE.replace("{id}", savedService.getId())));
+    }
 
     @Transactional
     @Override
@@ -67,61 +67,60 @@ public class ServiceApiController implements ServiceApi {
 
         scopeEntryRepository.deleteByService(service.get());
         serviceRepository.deleteById(id);
-
         return HttpResponse.noContent();
     }
 
-	@Override
-	public HttpResponse<List<String>> getScopeForService(@NonNull String id, @Nullable String oidcScope) {
-		Optional<Service> service = serviceRepository.findById(id);
-		if (service.isEmpty()) {
-			return HttpResponse.notFound();
-		}
-		String selectedOidcScope =
-				oidcScope == null ?
-						serviceMapper.map(service.get()).getDefaultOidcScope() :
-						oidcScope;
-		ServiceScopesEntryVO serviceScopesEntryVO = serviceMapper.map(service.get())
-				.getOidcScopes()
-				.get(selectedOidcScope);
-		return HttpResponse.ok(
-				Optional.ofNullable(
-								serviceScopesEntryVO.getCredentials())
-						.orElse(List.of()).stream().map(CredentialVO::getType).toList());
-	}
+    @Override
+    public HttpResponse<List<String>> getScopeForService(@NonNull String id, @Nullable String oidcScope) {
+        Optional<Service> service = serviceRepository.findById(id);
+        if (service.isEmpty()) {
+            return HttpResponse.notFound();
+        }
+        String selectedOidcScope =
+                oidcScope == null ?
+                        serviceMapper.map(service.get()).getDefaultOidcScope() :
+                        oidcScope;
+        ServiceScopesEntryVO serviceScopesEntryVO = serviceMapper.map(service.get())
+                .getOidcScopes()
+                .get(selectedOidcScope);
+        return HttpResponse.ok(
+                Optional.ofNullable(
+                                serviceScopesEntryVO.getCredentials())
+                        .orElse(List.of()).stream().map(CredentialVO::getType).toList());
+    }
 
-	@Override
-	public HttpResponse<ServiceVO> getService(@NonNull String id) {
-		Optional<ServiceVO> serviceVO = serviceRepository.findById(id)
-				.map(serviceMapper::map);
-		return serviceVO
-				.map(HttpResponse::ok)
-				.orElse(HttpResponse.notFound());
-	}
+    @Override
+    public HttpResponse<ServiceVO> getService(@NonNull String id) {
+        Optional<ServiceVO> serviceVO = serviceRepository.findById(id)
+                .map(serviceMapper::map);
+        return serviceVO
+                .map(HttpResponse::ok)
+                .orElse(HttpResponse.notFound());
+    }
 
-	@Override
-	public HttpResponse<ServicesVO> getServices(@Nullable Integer nullablePageSize,
-												@Nullable Integer nullablePage) {
-		var pageSize = Optional.ofNullable(nullablePageSize).orElse(100);
-		var page = Optional.ofNullable(nullablePage).orElse(0);
-		if (pageSize < 1) {
-			throw new IllegalArgumentException("PageSize has to be at least 1.");
-		}
-		if (page < 0) {
-			throw new IllegalArgumentException("Offsets below 0 are not supported.");
-		}
+    @Override
+    public HttpResponse<ServicesVO> getServices(@Nullable Integer nullablePageSize,
+                                                @Nullable Integer nullablePage) {
+        var pageSize = Optional.ofNullable(nullablePageSize).orElse(100);
+        var page = Optional.ofNullable(nullablePage).orElse(0);
+        if (pageSize < 1) {
+            throw new IllegalArgumentException("PageSize has to be at least 1.");
+        }
+        if (page < 0) {
+            throw new IllegalArgumentException("Offsets below 0 are not supported.");
+        }
 
-		Page<Service> requestedPage = serviceRepository.findAll(
-				Pageable.from(page, pageSize, Sort.of(Sort.Order.asc("id"))));
-		return HttpResponse.ok(
-				new ServicesVO()
-						.total((int) requestedPage.getTotalSize())
-						.pageNumber(page)
-						.pageSize(requestedPage.getContent().size())
-						.services(requestedPage.getContent().stream().map(serviceMapper::map).toList()));
-	}
+        Page<Service> requestedPage = serviceRepository.findAll(
+                Pageable.from(page, pageSize, Sort.of(Sort.Order.asc("id"))));
+        return HttpResponse.ok(
+                new ServicesVO()
+                        .total((int) requestedPage.getTotalSize())
+                        .pageNumber(page)
+                        .pageSize(requestedPage.getContent().size())
+                        .services(requestedPage.getContent().stream().map(serviceMapper::map).toList()));
+    }
 
-@Transactional
+    @Transactional
     @Override
     public HttpResponse<ServiceVO> updateService(@NonNull String id, @NonNull ServiceVO serviceVO) {
         if (serviceVO.getId() != null && !id.equals(serviceVO.getId())) {
@@ -143,85 +142,85 @@ public class ServiceApiController implements ServiceApi {
         Service toBeUpdated = serviceMapper.map(serviceVO);
         toBeUpdated.setId(id);
         Service updatedService = serviceRepository.update(toBeUpdated);
-        
+
         return HttpResponse.ok(serviceMapper.map(updatedService));
     }
 
-	// validate a service vo, e.g. check forbidden null values
-	private void validateServiceVO(ServiceVO serviceVO) {
-		if (serviceVO.getDefaultOidcScope() == null) {
-			throw new IllegalArgumentException("Default OIDC scope cannot be null.");
-		}
-		if (serviceVO.getOidcScopes() == null) {
-			throw new IllegalArgumentException("OIDC scopes cannot be null.");
-		}
+    // validate a service vo, e.g. check forbidden null values
+    private void validateServiceVO(ServiceVO serviceVO) {
+        if (serviceVO.getDefaultOidcScope() == null) {
+            throw new IllegalArgumentException("Default OIDC scope cannot be null.");
+        }
+        if (serviceVO.getOidcScopes() == null) {
+            throw new IllegalArgumentException("OIDC scopes cannot be null.");
+        }
 
-		String defaultOidcScope = serviceVO.getDefaultOidcScope();
-		ServiceScopesEntryVO serviceScopesEntryVO = serviceVO
-				.getOidcScopes()
-				.get(defaultOidcScope);
-		if (serviceScopesEntryVO == null) {
-			throw new IllegalArgumentException("Default OIDC scope must exist in OIDC scopes array.");
-		}
+        String defaultOidcScope = serviceVO.getDefaultOidcScope();
+        ServiceScopesEntryVO serviceScopesEntryVO = serviceVO
+                .getOidcScopes()
+                .get(defaultOidcScope);
+        if (serviceScopesEntryVO == null) {
+            throw new IllegalArgumentException("Default OIDC scope must exist in OIDC scopes array.");
+        }
 
-		Optional<CredentialVO> nullType = Optional.ofNullable(serviceScopesEntryVO
-						.getCredentials())
-				.orElse(List.of())
-				.stream()
-				.filter(cvo -> cvo.getType() == null)
-				.findFirst();
-		if (nullType.isPresent()) {
-			throw new IllegalArgumentException("Type of a credential cannot be null.");
-		}
+        Optional<CredentialVO> nullType = Optional.ofNullable(serviceScopesEntryVO
+                        .getCredentials())
+                .orElse(List.of())
+                .stream()
+                .filter(cvo -> cvo.getType() == null)
+                .findFirst();
+        if (nullType.isPresent()) {
+            throw new IllegalArgumentException("Type of a credential cannot be null.");
+        }
 
-		serviceVO
-				.getOidcScopes()
-				.values()
-				.forEach(this::validateKeyMappings);
-	}
+        serviceVO
+                .getOidcScopes()
+                .values()
+                .forEach(this::validateKeyMappings);
+    }
 
-	private void validateKeyMappings(ServiceScopesEntryVO scopeEntry) {
-		if (scopeEntry.getFlatClaims()) {
-			List<String> includedKeys = Optional.ofNullable(scopeEntry.getCredentials())
-					.orElse(List.of())
-					.stream()
-					.filter(cvo -> cvo.getJwtInclusion().getEnabled())
-					.flatMap(credentialVO ->
-							Optional.ofNullable(credentialVO.getJwtInclusion()
-											.getClaimsToInclude())
-									.orElse(List.of())
-									.stream()
-									.map(claim -> {
-										if (claim.getNewKey() != null && !claim.getNewKey().isEmpty()) {
-											return claim.getNewKey();
-										}
-										return claim.getOriginalKey();
-									})
-					).toList();
-			if (includedKeys.size() != new HashSet(includedKeys).size()) {
-				throw new IllegalArgumentException("Configuration contains duplicate claim keys.");
-			}
-		} else {
-			Optional.ofNullable(scopeEntry.getCredentials())
-					.orElse(List.of())
-					.stream()
-					.filter(cvo -> cvo.getJwtInclusion().getEnabled())
-					.forEach(cvo -> {
-						List<String> claimKeys = Optional.ofNullable(cvo.getJwtInclusion()
-										.getClaimsToInclude())
-								.orElse(List.of())
-								.stream()
-								.map(claim -> {
-									if (claim.getNewKey() != null && !claim.getNewKey().isEmpty()) {
-										return claim.getNewKey();
-									}
-									return claim.getOriginalKey();
-								})
-								.toList();
-						if (claimKeys.size() != new HashSet(claimKeys).size()) {
-							throw new IllegalArgumentException("Configuration contains duplicate claim keys.");
-						}
-					});
-		}
-	}
+    private void validateKeyMappings(ServiceScopesEntryVO scopeEntry) {
+        if (scopeEntry.getFlatClaims()) {
+            List<String> includedKeys = Optional.ofNullable(scopeEntry.getCredentials())
+                    .orElse(List.of())
+                    .stream()
+                    .filter(cvo -> cvo.getJwtInclusion().getEnabled())
+                    .flatMap(credentialVO ->
+                            Optional.ofNullable(credentialVO.getJwtInclusion()
+                                            .getClaimsToInclude())
+                                    .orElse(List.of())
+                                    .stream()
+                                    .map(claim -> {
+                                        if (claim.getNewKey() != null && !claim.getNewKey().isEmpty()) {
+                                            return claim.getNewKey();
+                                        }
+                                        return claim.getOriginalKey();
+                                    })
+                    ).toList();
+            if (includedKeys.size() != new HashSet(includedKeys).size()) {
+                throw new IllegalArgumentException("Configuration contains duplicate claim keys.");
+            }
+        } else {
+            Optional.ofNullable(scopeEntry.getCredentials())
+                    .orElse(List.of())
+                    .stream()
+                    .filter(cvo -> cvo.getJwtInclusion().getEnabled())
+                    .forEach(cvo -> {
+                        List<String> claimKeys = Optional.ofNullable(cvo.getJwtInclusion()
+                                        .getClaimsToInclude())
+                                .orElse(List.of())
+                                .stream()
+                                .map(claim -> {
+                                    if (claim.getNewKey() != null && !claim.getNewKey().isEmpty()) {
+                                        return claim.getNewKey();
+                                    }
+                                    return claim.getOriginalKey();
+                                })
+                                .toList();
+                        if (claimKeys.size() != new HashSet(claimKeys).size()) {
+                            throw new IllegalArgumentException("Configuration contains duplicate claim keys.");
+                        }
+                    });
+        }
+    }
 }


### PR DESCRIPTION
build(deps): update jakarta-persistence-api from 3.1.0 to 3.2.0
build(deps): replace deprecated org.eluder.coveralls with com.github.hazendaz.maven
build(deps): update jacoco from 0.8.12 to 0.8.14
build(deps): update build-helper-maven-plugin from 3.4.0 to 3.6.1
build(deps): replace mockito-all with mockito-core 5.21.0
build(deps): update openapitools from 6.6.0 to 7.17.0
build(deps): update lombok from 1.18.36 to 1.18.42
build(deps): update mapstruct from 1.5.3.Final to 1.6.3
build(deps): update micronaut from 4.8.2 to 4.10.6